### PR TITLE
Fixed fourfield date-issues on Firefox

### DIFF
--- a/portfolio_manager/models.py
+++ b/portfolio_manager/models.py
@@ -457,16 +457,16 @@ class PathSnapshot(Snapshot):
     project_id = models.CharField(max_length=64)
     x_id = models.CharField(max_length=64)
     y_id = models.CharField(max_length=64)
-    start_date = models.DateField()
-    end_date = models.DateField()
+    start_date = models.PositiveIntegerField()
+    end_date = models.PositiveIntegerField()
 
 
 class FourFieldSnapshot(Snapshot):
     x_dimension = models.CharField(max_length=64)
     y_dimension = models.CharField(max_length=64)
     radius_dimension = models.CharField(max_length=64)
-    start_date = models.DateField()
-    end_date = models.DateField()
+    start_date = models.PositiveIntegerField()
+    end_date = models.PositiveIntegerField()
     zoom = models.PositiveIntegerField()
 
 
@@ -527,5 +527,5 @@ def create_groups(sender, instance, created, **kwargs):
 
         e.save()
         a.save()
-        
+
 post_save.connect(create_groups, sender=Organization)

--- a/portfolio_manager/static/portfolio_manager/js/snapshot/snap_fourfield_loader.js
+++ b/portfolio_manager/static/portfolio_manager/js/snapshot/snap_fourfield_loader.js
@@ -21,8 +21,8 @@ $(function(){
       x = djdata['x'],
       y = djdata['y'],
       r = djdata['r'],
-      start = Date.parse(djdata['start'])/1000,
-      end = Date.parse(djdata['end'])/1000,
+      start = djdata['start'],
+      end = djdata['end'],
       zoom = djdata['zoom'],
       data = djdata['data'];
 

--- a/portfolio_manager/static/portfolio_manager/js/snapshot/snap_path_loader.js
+++ b/portfolio_manager/static/portfolio_manager/js/snapshot/snap_path_loader.js
@@ -21,12 +21,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 $(function() {
 
   var djdata = $("#dj-data").data(),
-  start_date = Date.parse(djdata['start']),
-  end_date = Date.parse(djdata['end']),
+  start_date = djdata['start'],
+  end_date = djdata['end'],
   project_id = djdata['project'],
   y_dimension_id = djdata['y']
   x_dimension_ids = [];
-  
+
   if(typeof djdata['x'] == "string") {
   	if(djdata['x'] != "") {
       x_dimension_ids = djdata['x'].trim().split(",");

--- a/portfolio_manager/templates/snapshots/single/fourfield.html
+++ b/portfolio_manager/templates/snapshots/single/fourfield.html
@@ -17,6 +17,7 @@ Fourfield Snapshot
 <script src="{% static 'portfolio_manager/js/snapshot/snap_fourfield_loader.js' %}"></script>
 {% endblock %}
 
+{% load timetags %}
 {% block content %}
 <div class="text-center">
   <h2>{{ name }}</h2>
@@ -64,7 +65,7 @@ Fourfield Snapshot
           Start date
         </div>
         <div class="panel-body">
-          {{ start_date }}
+          {{ start_date | print_timestamp }}
         </div>
       </div>
       <div class="panel panel-default">
@@ -72,7 +73,7 @@ Fourfield Snapshot
           End date
         </div>
         <div class="panel-body">
-          {{ end_date }}
+          {{ end_date | print_timestamp }}
         </div>
       </div>
       <div class="panel panel-default">

--- a/portfolio_manager/templatetags/timetags.py
+++ b/portfolio_manager/templatetags/timetags.py
@@ -1,0 +1,12 @@
+from django import template
+import datetime
+register = template.Library()
+
+def print_timestamp(timestamp):
+    try:
+        ts = float(timestamp)
+    except ValueError:
+        return None
+    return datetime.datetime.fromtimestamp(ts).strftime("%Y-%m-%d")
+
+register.filter(print_timestamp)

--- a/portfolio_manager/views.py
+++ b/portfolio_manager/views.py
@@ -918,8 +918,8 @@ def create_snapshot(request):
             y = request.POST['y_dim']
             start_ddmmyyyy = request.POST['start-date']
             end_ddmmyyyy = request.POST['end-date']
-            start = dt.datetime.strptime(start_ddmmyyyy, "%d/%m/%Y").strftime("%Y-%m-%d")
-            end = dt.datetime.strptime(end_ddmmyyyy, "%d/%m/%Y").strftime("%Y-%m-%d")
+            start = time.mktime((datetime.strptime(start_ddmmyyyy, "%d/%m/%Y")).timetuple())
+            end = time.mktime((datetime.strptime(end_ddmmyyyy, "%d/%m/%Y")).timetuple())
 
             p_snap = create_pathsnapshot(
                         name=name,
@@ -941,8 +941,8 @@ def create_snapshot(request):
 
             name = request.POST['name']
             description = request.POST['description']
-            start = dt.datetime.strptime(start_ddmmyyyy, "%d/%m/%Y").strftime("%Y-%m-%d")
-            end = dt.datetime.strptime(end_ddmmyyyy, "%d/%m/%Y").strftime("%Y-%m-%d")
+            start = time.mktime((datetime.strptime(start_ddmmyyyy, "%d/%m/%Y")).timetuple())
+            end = time.mktime((datetime.strptime(end_ddmmyyyy, "%d/%m/%Y")).timetuple())
             zoom = request.POST['zoom']
 
             ff_snap = create_fourfieldsnapshot(


### PR DESCRIPTION
Fixed fourfield snapshot date issues on firefox. Added new templatetag "timetags", which is used in templates/snapshots/single/fourfield.html to format timestamps.

https://trello.com/c/5w72upsT
