### PR TITLE
fourfield slider fixed on safari.

### DIFF
--- a/portfolio_manager/static/portfolio_manager/css/fourField.css
+++ b/portfolio_manager/static/portfolio_manager/css/fourField.css
@@ -42,6 +42,11 @@ text {
   pointer-events: all;
   cursor: ew-resize;
 }
+.track,
+.track-inset,
+.track-overlay {
+  stroke-linecap: round;
+}
 
 .track {
   stroke: #000;
@@ -57,6 +62,7 @@ text {
 .track-overlay {
   pointer-events: stroke;
   stroke-width: 50px;
+  stroke: transparent;
 }
 
 .handle {


### PR DESCRIPTION
Fourfield fixed on safari. Added several lines to fourfield.css. Fourfield should now function on Edge, Safari, Firefox and Chrome.

https://trello.com/c/wzJqIXCe