### PR TITLE
Safari now draws the legend correctly

### DIFF
--- a/portfolio_manager/static/portfolio_manager/js/projectDependencies.js
+++ b/portfolio_manager/static/portfolio_manager/js/projectDependencies.js
@@ -364,7 +364,7 @@ function dependancies(json) {
         .each(function(d,i){
           var thisWidth = this.getComputedTextLength()
           textWidth.push(thisWidth)
-          this.remove()
+          $(this).remove();
         })
 
     maxTextLength = d3.max(textWidth)


### PR DESCRIPTION
Turns out safari is more strict with JQuery than the rest of the browsers. Other browsers didn't react to a syntax error

https://trello.com/c/tSSuWd3s