### PR TITLE
Fixed an issue with snapshot startdate

### DIFF
--- a/portfolio_manager/static/portfolio_manager/js/fourField.js
+++ b/portfolio_manager/static/portfolio_manager/js/fourField.js
@@ -197,8 +197,7 @@ function fourField(json, xToBe, yToBe, radToBe, startDate, endDate, sliderValues
 		$('#end-date-selector').val(ddmmyy(endDate*1000));
 	}
 	if (isNaN(sliderDate)) {
-		sliderDate = startDefault;
-		$('#start-date-selector').val(ddmmyy(startDate*1000));
+		sliderDate = startDate;
 	} else if(sliderDate < startDate) {
 		sliderDate = startDate;
 	} else if(sliderDate > endDate) {


### PR DESCRIPTION
https://trello.com/c/4CEDDmp4

Fourfield snapshot now starts with the correct startdate
when fourfield is initialized without "slidervalue", as is done in snapshots, it used StartDefault (first date in data) instead of startdate to set the date and circle positions. Now sliderdate is set to startDate if it starts undefined