### PR TITLE
timestamps sent by snap path loader are now in ms (instead of s) and …

### DIFF
--- a/portfolio_manager/static/portfolio_manager/js/snapshot/snap_path_loader.js
+++ b/portfolio_manager/static/portfolio_manager/js/snapshot/snap_path_loader.js
@@ -52,8 +52,8 @@ $(function() {
           db_json,
           "visualization",
           data_id_array,
-          start_date,
-          end_date
+          (start_date * 1000),
+          (end_date * 1000)
         );
 
     $("#projectPanel").html($("#projectName").text())

--- a/portfolio_manager/templates/snapshots/single/path.html
+++ b/portfolio_manager/templates/snapshots/single/path.html
@@ -17,6 +17,7 @@
 <script src="{% static 'portfolio_manager/js/snapshot/snap_path_loader.js' %}"></script>
 {% endblock %}
 
+{% load timetags %}
 {% block content %}
 {% load static %}
 <div class="text-center ">
@@ -60,7 +61,7 @@
             Start date
           </div>
           <div class="panel-body">
-            {{ start }}
+            {{ start | print_timestamp }}
           </div>
         </div>
         <div class="panel panel-default">
@@ -68,7 +69,7 @@
             End date
           </div>
           <div class="panel-body">
-            {{ end }}
+            {{ end | print_timestamp }}
           </div>
         </div>
       </div>

--- a/portfolio_manager/templatetags/timetags.py
+++ b/portfolio_manager/templatetags/timetags.py
@@ -7,6 +7,6 @@ def print_timestamp(timestamp):
         ts = float(timestamp)
     except ValueError:
         return None
-    return datetime.datetime.fromtimestamp(ts).strftime("%Y-%m-%d")
+    return datetime.datetime.fromtimestamp(ts).strftime("%d/%m/%Y")
 
 register.filter(print_timestamp)


### PR DESCRIPTION
…path uses timetags-filter.

https://trello.com/c/oynMTcUG

timestamps are sent to path.js in ms instead of s and the template uses timetags-filter