### PR TITLE
Project edit default values

### DIFF
--- a/portfolio_manager/static/portfolio_manager/js/modify_project.js
+++ b/portfolio_manager/static/portfolio_manager/js/modify_project.js
@@ -165,3 +165,20 @@ $(function()
     error: function() { ajax_error(); }
   });
 });
+//set the modal default value when opened
+$( document ).ready(function() {
+  $(".modify-button").click(function() {
+    button = $(this);
+    value = button.closest(".panel-default").find(".col-lg-3")[0].innerText;
+    type = button[0].dataset.type;
+    if(type === "date"){
+      value = stringToCorrectFormat(value);
+    }
+    $("#modify-" + type + "-modal").find("#"+ type + "-value").val(value);
+  });
+});
+
+function stringToCorrectFormat(string) {
+  list = string.split("/");
+  return list[2] + "-" + list[1] + "-" + list[0];
+}

--- a/portfolio_manager/static/portfolio_manager/js/modify_project.js
+++ b/portfolio_manager/static/portfolio_manager/js/modify_project.js
@@ -169,12 +169,14 @@ $(function()
 $( document ).ready(function() {
   $(".modify-button").click(function() {
     button = $(this);
-    value = button.closest(".panel-default").find(".col-lg-3")[0].innerText;
+    value = button[0].getAttribute("hiddenvalue");
     type = button[0].dataset.type;
     if(type === "date"){
       value = stringToCorrectFormat(value);
+    } else if(type ==="associatedorganization" || type ==="associatedperson" ) {
+      value = button[0].getAttribute("selectvalue");
     }
-    $("#modify-" + type + "-modal").find("#"+ type + "-value").val(value);
+    $("#modify-" + type + "-modal").find("#"+ type + "-value").val(value).trigger("change");
   });
 });
 

--- a/portfolio_manager/templates/project.html
+++ b/portfolio_manager/templates/project.html
@@ -84,6 +84,8 @@ Projects | {{project.name}}
             <!--  Modify button  -->
             <div class="col-md-1 pull-right">
               <button id="{{dim_name}}-modifybtn" class="btn btn-xs btn-default modify-button"
+                  hiddenvalue="{{ dim_obj | stringformat:"s" }}"
+                  selectvalue="{{dim_obj.value.id}}"
                   data-type="{{ dim_type | get_type }}"
                   data-field="{{ dim_obj.id }}"
                   data-valuetype="{{ dim_type | get_type | get_valuetype }}"


### PR DESCRIPTION
modify modal in project view now shows current value as default. The button has all the needed data stored in its attributes. hiddenvalue has the value as string and selectvalue has the id of the object used to select it in the dropdown menu (someone could name those attributes better...).

If the field is a associated person or -organization the selectvalue is used to pre-select the correct object from the dropdown. If the field is date, the date-string is converted to a correct format for datepicker (YYYY-MM-DD), and the rest of the fields simply use the string as it is.

https://trello.com/c/i1ao5EAr