### PR TITLE
Fixed the small filter problem

### DIFF
--- a/portfolio_manager/views.py
+++ b/portfolio_manager/views.py
@@ -472,7 +472,7 @@ def show_project(request, project_id):
                 #user is not an admin in this group
                 pass
         #filter the projects
-        projects = filter(lambda project: project.parent.id in orgs, all_projects)
+        projects = list(filter(lambda project: project.parent.id in orgs, all_projects))
         if(not project in projects):
             raise Http404
     else:


### PR DESCRIPTION
This is just a small fix on the project-page projectlist, the list would only contain projects with larger id than the id of the project you were viewing. You can see the problem by picking a project with as large id you can.

https://trello.com/c/KAnPZFyu